### PR TITLE
Styling, Log output cleaner, Fix setting DOCKER_TLS_VERIFY

### DIFF
--- a/docker-container/README.md
+++ b/docker-container/README.md
@@ -4,7 +4,7 @@ Three providers in this plugin:
 
 * ResourceModelSource: Lists the containers as nodes
 * NodeExecutor: Execute a command in a container via Command step or Commands page.
-* WorkflowNodeSteps: 
+* WorkflowNodeSteps:
   * exec
   * inspect  
   * kill

--- a/docker-container/contents/container-inspect
+++ b/docker-container/contents/container-inspect
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,41 +6,62 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('docker-inspect')
 
-
 parser = argparse.ArgumentParser(
-    description='Run the inspect command for the container.')
+    description='Run the inspect command for the container.'
+)
 parser.add_argument('container', help='the container ID')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
 
-p = Popen(shlex.split('docker inspect %s' % (args.container)),
-          shell=False, stdout=PIPE, stderr=PIPE)
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
+
+p = Popen(
+    shlex.split('docker inspect %s' % (args.container)),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/contents/container-kill
+++ b/docker-container/contents/container-kill
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,42 +6,63 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('docker-kill')
 
-
 parser = argparse.ArgumentParser(
-    description='Pause all processes in the container.')
+    description='Pause all processes in the container.'
+)
 parser.add_argument('container', help='the container ID')
 parser.add_argument('signal', help='signal to send the container')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
 
-p = Popen(shlex.split('docker kill %s' % (args.container)),
-          shell=False, stdout=PIPE, stderr=PIPE)
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
+
+p = Popen(
+    shlex.split('docker kill %s' % (args.container)),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/contents/container-pause
+++ b/docker-container/contents/container-pause
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,41 +6,62 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('docker-pause')
 
-
 parser = argparse.ArgumentParser(
-    description='Pause all processes in the container.')
+    description='Pause all processes in the container.'
+)
 parser.add_argument('container', help='the container ID')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
 
-p = Popen(shlex.split('docker pause %s' % (args.container)),
-          shell=False, stdout=PIPE, stderr=PIPE)
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
+
+p = Popen(
+    shlex.split('docker pause %s' % (args.container)),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/contents/container-stats
+++ b/docker-container/contents/container-stats
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,11 +6,17 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
-log = logging.getLogger('docker-stats')
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
 
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
+log = logging.getLogger('docker-stats')
 
 parser = argparse.ArgumentParser(
     description='Pause all processes in the container.')
@@ -19,30 +24,44 @@ parser.add_argument('container', help='the container ID')
 parser.add_argument('format', help='the Go format template')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
 
-p = Popen(shlex.split('docker stats --no-stream --format "%s" %s' % (args.format, args.container)),
-          shell=False, stdout=PIPE, stderr=PIPE)
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
+
+p = Popen(
+    shlex.split('docker stats --no-stream --format "%s" %s' % (args.format, args.container)),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/contents/container-unpause
+++ b/docker-container/contents/container-unpause
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,41 +6,62 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('docker-unpause')
 
-
 parser = argparse.ArgumentParser(
-    description='Pause all processes in the container.')
-parser.add_argument('container', help='the container ID')
+    description='Pause all processes in the container.'
+)
+parser.add_argument('container', help='The container ID')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
 
-p = Popen(shlex.split('docker unpause %s' % (args.container)),
-          shell=False, stdout=PIPE, stderr=PIPE)
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
+
+p = Popen(
+    shlex.split('docker unpause %s' % (args.container)),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/contents/model-source
+++ b/docker-container/contents/model-source
@@ -1,28 +1,32 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
 import sys
 import os
-
-from subprocess import Popen, PIPE
 import json
-import shlex
+from subprocess import Popen, PIPE
 
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
 
-logging.basicConfig(stream=sys.stderr, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+logging.basicConfig(
+    stream=sys.stderr,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('container-model-source')
 
 
 def nodeCollectData(containerId, json, defaults, taglist):
-    log.debug("Parsing json data for container: %s" % containerId)
-    tags = ["docker"]
-    tags.extend(taglist.split(","))
+    log.debug('Parsing json data for container: %s' % containerId)
+    tags = ['docker']
+    tags.extend(taglist.split(','))
     data = {
         'nodename': containerId,
-        'tags': ",".join(tags),
+        'tags': ','.join(tags),
         'docker:Id': json[0]["Id"],
         'docker:Created': json[0]["Created"],
         'docker:Name': json[0]["Name"],
@@ -42,41 +46,50 @@ def nodeCollectData(containerId, json, defaults, taglist):
     return data
 
 
-if os.environ.get('RD_CONFIG_DEBUG') == 'true':
-    log.setLevel(logging.DEBUG)
-    log.debug("Log level configured for DEBUG")
-
 parser = argparse.ArgumentParser(
-    description='Execute a command string in the container.')
+    description='Execute a command string in the container.'
+)
 parser.add_argument('defaults', help='key=value list')
 parser.add_argument('tags', help='comma separated list of additonal tags')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.debug("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.debug("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.debug("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
+
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
 
 # Get a listing of the docker containers
-log.debug("Executing `docker ps --format {{.ID}}` ...")
-ps = Popen('docker ps --format "{{.ID}}"',
-           shell=True, stdout=PIPE, stderr=PIPE,
-           bufsize=1, universal_newlines=True)
+log.debug('Executing `docker ps --format {{.ID}}` ...')
+ps = Popen(
+    'docker ps --format "{{.ID}}"',
+    shell=True,
+    stdout=PIPE,
+    stderr=PIPE,
+    bufsize=1,
+    universal_newlines=True
+)
 exitcode = ps.wait()
-if exitcode != 0:
-    log.error("Failure from docker ps command (exitcode: %s)" % str(exitcode))
-    sys.exit(1)
 
+if exitcode != 0:
+    log.error('Failure from docker ps command (exitcode: %s)' % str(exitcode))
+    sys.exit(exitcode)
 
 containers = ps.stdout.readlines()
 log.debug('Processing %d containers ...' % len(containers))
@@ -84,16 +97,22 @@ node_set = []
 
 for container in containers:
     log.debug('Inspecting container: %s' % container)
-    inspect = Popen(shlex.split('docker inspect %s ' % container),
-                    shell=False, stdout=PIPE, stderr=PIPE,
-                    bufsize=1, universal_newlines=True)
+    inspect = Popen(
+        shlex.split('docker inspect %s ' % container),
+        shell=False,
+        stdout=PIPE,
+        stderr=PIPE,
+        bufsize=1,
+        universal_newlines=True
+    )
     inspect_json = json.load(inspect.stdout)
-    node_data = nodeCollectData(container.rstrip('\n'),
-                                inspect_json,
-                                args.defaults,
-                                args.tags)
+    node_data = nodeCollectData(
+        container.rstrip('\n'),
+        inspect_json,
+        args.defaults,
+        args.tags
+    )
     node_set.append(node_data)
 
-
 # done
-print json.dumps(node_set, indent=4, sort_keys=True)
+print(json.dumps(node_set, indent=4, sort_keys=True))

--- a/docker-container/contents/node-execute
+++ b/docker-container/contents/node-execute
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,46 +6,69 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('docker-node-executor')
 
-
 parser = argparse.ArgumentParser(
-    description='Execute a command string in the container.')
+    description='Execute a command string in the container.'
+)
 parser.add_argument('container', help='the container ID')
 parser.add_argument('user', help='the user ID')
 parser.add_argument('command', help='the command string to execute')
 args = parser.parse_args()
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
 
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
 
-log.info("Executing command string '%s' in container '%s' ..." % (args.command, args.container))
+log.debug(
+    "Executing command string '%s' in container '%s'"
+    "..." % (args.command, args.container)
+)
 
-p = Popen(shlex.split('docker exec %s %s' % (args.container, args.command)),
-          shell=False, stdout=PIPE, stderr=PIPE)
+p = Popen(
+    shlex.split('docker exec %s %s' % (args.container, args.command)),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/contents/run-image
+++ b/docker-container/contents/run-image
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-
 import argparse
 import logging
 import shlex
@@ -7,27 +6,32 @@ import sys
 import os
 from subprocess import Popen, PIPE
 
+if os.environ.get('RD_CONFIG_DEBUG') == 'true':
+    log_level = 'DEBUG'
+else:
+    log_level = 'ERROR'
 
-formatter = logging.Formatter()
-logging.basicConfig(stream=sys.stdout, level=logging.INFO,
-                    format='%(levelname)s: %(name)s: %(message)s')
+logging.basicConfig(
+    stream=sys.stdout,
+    level=getattr(logging, log_level),
+    format='%(levelname)s: %(name)s: %(message)s'
+)
 log = logging.getLogger('docker-run')
 
-
 parser = argparse.ArgumentParser(
-    description='Start a container with the specified image.')
+    description='Start a container with the specified image.'
+)
 parser.add_argument('image', help='the image to run')
 parser.add_argument('command', help='the command to run')
 args = parser.parse_args()
-
 
 possible_opts = ['add-host', 'blkio-weight', 'cap-add', 'cap-drop', 'cidfile',
                  'cpu-shares', 'cpu-period', 'cpuset-cpus', 'cpuset-mems',
                  'cpu-quota', 'detach', 'device', 'dns', 'env', 'interactive',
                  'ipc', 'label', 'log-driver', 'log-opt', 'lxc-conf', 'memory',
                  'memory-swap', 'name', 'net', 'oom-kill-disable', 'publish',
-                 'privileged', 'restart', 'rm', 'security-opt',
-                 'volume', 'volume-from', 'ulimit', 'uts', 'tty','workdir']
+                 'privileged', 'restart', 'rm', 'security-opt', 'volume',
+                 'volume-from', 'ulimit', 'uts', 'tty', 'workdir', 'user']
 OPTIONS = []
 
 for env_var_name, env_var_value in os.environ.iteritems():
@@ -36,29 +40,38 @@ for env_var_name, env_var_value in os.environ.iteritems():
        env_var_name.startswith('RD_JOB')) and \
        env_var_value:
         OPTIONS.append("--env=%s='%s'" % (env_var_name, env_var_value))
-        log.debug("appended option: --env=%s='%s'" % (env_var_name, env_var_value))
+        log.debug(
+            "appended option: --env=%s='%s'" % (env_var_name, env_var_value)
+        )
 
 for opt in possible_opts:
-    env_var_name = "RD_CONFIG_" + opt.upper().replace('-', '_')
+    env_var_name = "RD_CONFIG_%s" % opt.upper().replace('-', '_')
     if env_var_name in os.environ:
         for env_var_value in shlex.split(os.environ[env_var_name]):
             OPTIONS.append("--%s='%s'" % (opt, env_var_value))
             log.debug("appended option: --%s='%s'" % (opt, env_var_value))
 
-if "RD_CONFIG_DOCKER_HOST" in os.environ:
-    os.environ["DOCKER_HOST"] = os.environ["RD_CONFIG_DOCKER_HOST"]
-    log.info("DOCKER_HOST set to " + os.environ["RD_CONFIG_DOCKER_HOST"])
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
+    log.debug('DOCKER_HOST set to %s' % os.environ['RD_CONFIG_DOCKER_HOST'])
 else:
-    log.debug("RD_CONFIG_DOCKER_HOST environment variable not defined.")
+    log.debug('RD_CONFIG_DOCKER_HOST environment variable not defined.')
 
-if "RD_CONFIG_DOCKER_CERT_PATH" in os.environ:
-    os.environ["DOCKER_CERT_PATH"] = os.environ["RD_CONFIG_DOCKER_CERT_PATH"]
-    log.info("DOCKER_CERT_PATH=" + os.environ["RD_CONFIG_DOCKER_CERT_PATH"])
-    if "RD_CONFIG_DOCKER_TLS_VERIFY" in os.environ:
-        os.environ["DOCKER_TLS_VERIFY"] = os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"]
-        log.info("DOCKER_TLS_VERIFY=" + os.environ["RD_CONFIG_DOCKER_TLS_VERIFY"])
-    else:
-        log.debug("RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.")
+if 'RD_CONFIG_DOCKER_CERT_PATH' in os.environ:
+    os.environ['DOCKER_CERT_PATH'] = os.environ['RD_CONFIG_DOCKER_CERT_PATH']
+    log.debug('DOCKER_CERT_PATH=%s' % os.environ['RD_CONFIG_DOCKER_CERT_PATH'])
+else:
+    log.debug('RD_CONFIG_DOCKER_CERT_PATH environment variable not defined.')
+
+if 'RD_CONFIG_DOCKER_TLS_VERIFY' in os.environ:
+    os.environ['DOCKER_TLS_VERIFY'] = os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    log.debug(
+        'DOCKER_TLS_VERIFY=%s' % os.environ['RD_CONFIG_DOCKER_TLS_VERIFY']
+    )
+else:
+    log.debug(
+        'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
+    )
 
 if args.command in {'${option.command}', '${config.command}'}:
     args.command = None
@@ -71,16 +84,24 @@ if args.command is not None:
     COMMAND.append(args.command)
 
 command_string = " ".join(COMMAND)
-log.info("Executing: '" + command_string + "' ...")
-# exitcode = subprocess.check_output(command_string, shell=True)
-p = Popen(shlex.split(command_string), shell=False, stdout=PIPE, stderr=PIPE)
+log.debug("Executing: '%s' ..." % command_string)
+
+p = Popen(
+    shlex.split(command_string),
+    shell=False,
+    stdout=PIPE,
+    stderr=PIPE
+)
 exitcode = p.wait()
 
-log.info("Command execution stdout: '" + p.stdout.read() + "' ...")
-log.info("Command execution stderr: '" + p.stderr.read() + "' ...")
+if log_level == 'DEBUG':
+    log.debug("Command execution stdout: '%s' ..." % p.stdout.read())
+    log.debug("Command execution stderr: '%s' ..." % p.stderr.read())
+else:
+    print(p.stdout.read())
 
 if exitcode != 0:
-    log.error("Command execution failed with exit code: %s" % str(exitcode))
+    log.error('Command execution failed with exit code: %s' % str(exitcode))
 
 # done
 sys.exit(exitcode)

--- a/docker-container/plugin.yaml
+++ b/docker-container/plugin.yaml
@@ -1,13 +1,13 @@
 name: docker-container-node-executor
-version: 1.1.0
+version: 1.3.0
 rundeckPluginVersion: 1.2
 author: alexh
-date: Thu Aug  6 19:32:08 PDT 2015
+date: Thu Aug 6 19:32:08 PDT 2015
 providers:
   - name: docker-container-execute-command
     service: WorkflowNodeStep
     title: docker / container / execute
-    description: 'execute the command in the container'
+    description: 'Execute the command in an existing container'
     plugin-type: script
     script-interpreter: python -u
     script-file: node-execute
@@ -16,37 +16,41 @@ providers:
       - type: String
         name: container
         title: 'container'
-        description: "the container to dispatch the command"
+        description: 'The container to dispatch the command'
         required: true
       - type: String
         name: command
         title: 'command'
-        description: "the command string to execute in the container"
+        description: 'The command string to execute in the container'
         required: true
       - type: String
         name: user
         title: 'User'
-        description: "User to execute command as."
+        description: 'User to execute command as.'
         default: root
         required: true
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
       - type: String
         name: docker-cert-path
         title: 'docker-cert-path'
-        description: "the certificate path"
+        description: 'The certificate path'
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'
       - type: String
         name: docker-host
         title: 'docker-host'
-        description: "the docker host"
+        description: 'The docker host'
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'
       - type: Select
         name: docker-tls-verify
         title: 'docker-tls-verify'
-        description: "verify TLS"
+        description: 'Verify TLS'
         default: '1'
         values: 1,0
         renderingOptions:
@@ -55,7 +59,7 @@ providers:
   - name: docker-container-node-executor
     service: NodeExecutor
     title: docker-container-node-executor
-    description: 'dispatch the command to the container'
+    description: 'Dispatch the command to an existing container'
     plugin-type: script
     script-interpreter: python -u
     script-file: node-execute
@@ -64,20 +68,24 @@ providers:
       - type: String
         name: docker-cert-path
         title: 'docker-cert-path'
-        description: "the certificate path"
+        description: 'The certificate path'
       - type: String
         name: docker-host
         title: 'docker-host'
-        description: "the docker host"
+        description: 'The docker host'
       - type: Select
         name: docker-tls-verify
         title: 'docker-tls-verify'
-        description: "verify TLS"
+        description: 'Verify TLS'
         values: 1,0
       - type: String
         name: container
         title: 'container'
-        description: "the container to dispatch."
+        description: 'The container to dispatch.'
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
   - name: docker-container-model-source
     service: ResourceModelSource
     resource-format: resourcejson
@@ -91,28 +99,28 @@ providers:
       - type: String
         name: docker-cert-path
         title: 'docker-cert-path'
-        description: "the certificate path"
+        description: 'The certificate path'
       - type: String
         name: docker-host
         title: 'docker-host'
-        description: "the docker host"
+        description: 'The docker host'
       - type: Select
         name: docker-tls-verify
         title: 'docker-tls-verify'
-        description: "verify TLS"
+        description: 'Verify TLS'
         values: 1,0
       - type: String
         name: attributes
         title: 'Default attributes'
-        description: "List of key=value pairs"
+        description: 'List of key=value pairs'
       - type: String
         name: tags
         title: Tags
-        description: "List of tags"
+        description: 'List of tags'
       - type: Boolean
         name: debug
         title: Debug?
-        description: "Write debug messages to stderr"
+        description: 'Write debug messages to stderr'
   - name: docker-container-inspect-workflow-step
     service: WorkflowNodeStep
     title: docker / container / inspect
@@ -124,7 +132,11 @@ providers:
     config:
       - type: String
         name: container
-        description: "The container ID"
+        description: 'The container ID'
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
   - name: docker-container-pause-step
     service: WorkflowNodeStep
     title: docker / container / pause
@@ -136,7 +148,11 @@ providers:
     config:
       - type: String
         name: container
-        description: "The container ID"
+        description: 'The container ID'
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
   - name: docker-container-unpause-step
     service: WorkflowNodeStep
     title: docker / container / unpause
@@ -148,7 +164,11 @@ providers:
     config:
       - type: String
         name: container
-        description: "The container ID"
+        description: 'The container ID'
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
   - name: docker-container-kill-step
     service: WorkflowNodeStep
     title: docker / container / kill
@@ -160,11 +180,15 @@ providers:
     config:
       - type: String
         name: container
-        description: "The container ID"
+        description: 'The container ID'
       - type: String
         name: signal
-        description: "Signal to send to the container"
+        description: 'Signal to send to the container'
         default: KILL
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
   - name: docker-container-stats-step
     service: WorkflowNodeStep
     title: docker / container / stats
@@ -176,15 +200,19 @@ providers:
     config:
       - type: String
         name: container
-        description: "The container ID"
+        description: 'The container ID'
       - type: String
         name: format
-        description: "Pretty-print images using a Go template"
+        description: 'Pretty-print images using a Go template'
         default: 'table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}\t{{.BlockIO}}'
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
   - name: docker-run-workflow-step
     service: WorkflowNodeStep
     title: docker / image / run
-    description: 'run the image'
+    description: 'Run the image and execute command'
     plugin-type: script
     script-interpreter: python -u
     script-file: run-image
@@ -193,188 +221,196 @@ providers:
       - type: String
         name: add-host
         title: 'add-host'
-        description: "Add a line to /etc/hosts (host:IP)"
+        description: 'Add a line to /etc/hosts (host:IP)'
       - type: Integer
         name: blkio-weight
         title: 'blkio-weight'
-        description: "Block IO weight (relative weight) accepts a weight value between 10 and 1000."
+        description: 'Block IO weight (relative weight) accepts a weight value between 10 and 1000.'
       - type: String
         name: cap-add
         title: 'cap-add'
-        description: "Add Linux capabilities"
+        description: 'Add Linux capabilities'
       - type: String
         name: cap-drop
         title: 'cap-drop'
-        description: "Drop Linux capabilities"
+        description: 'Drop Linux capabilities'
       - type: String
         name: cidfile
         title: 'cidfile'
-        description: "Write the container ID to the file"
+        description: 'Write the container ID to the file'
       - type: String
         name: command
         title: 'command'
-        description: "Run this command at start up"
+        description: 'Run this command at start up'
       - type: Integer
         name: cpu-period
         title: 'cpu-period'
-        description: "Limit the CPU CFS (Completely Fair Scheduler) period"
+        description: 'Limit the CPU CFS (Completely Fair Scheduler) period'
       - type: Integer
         name: cpu-quota
         title: 'cpu-quota'
-        description: "Limit the CPU CFS (Completely Fair Scheduler) quota"
+        description: 'Limit the CPU CFS (Completely Fair Scheduler) quota'
       - type: Integer
         name: cpu-shares
         title: 'cpu-shares'
-        description: "CPU shares (relative weight)"
+        description: 'CPU shares (relative weight)'
       - type: String
         name: cpuset-cpus
         title: 'cpuset-cpus'
-        description: "CPUs in which to allow execution (0-3, 0,1)"
+        description: 'CPUs in which to allow execution (0-3, 0,1)'
       - type: String
         name: cpuset-mems
         title: 'cpuset-mems'
-        description: "Memory nodes (MEMs) in which to allow execution (0-3, 0,1)"
+        description: 'Memory nodes (MEMs) in which to allow execution (0-3, 0,1)'
       - type: Select
         name: detach
         title: 'detach'
-        description: "Run container in background and print container ID"
+        description: 'Run container in background and print container ID'
         values: true,false
       - type: String
         name: device
         title: 'device'
-        description: "Allows you to run devices inside the container without the --privileged flag"
+        description: 'Allows you to run devices inside the container without the --privileged flag'
       - type: String
         name: dns
         title: 'dns'
-        description: "Set custom dns servers for the container"
+        description: 'Set custom dns servers for the container'
       - type: String
         name: env
         title: 'environment variables'
-        description: "Set of environment variables."
+        description: 'Set of environment variables.'
       - type: String
         name: image
         title: 'image'
-        description: "The container image identifier"
+        description: 'The container image identifier'
         required: true
       - type: FreeSelect
         name: ipc
         title: 'ipc'
-        description: "Set the IPC mode for the container"
+        description: 'Set the IPC mode for the container'
         values: host,container:<name|id>
       - type: Select
         name: log-driver
         title: 'log-driver'
-        description: "Logging driver for container"
+        description: 'Logging driver for container'
         values: none,json-file,syslog,journald
       - type: String
         name: log-opt
         title: 'log-opt'
-        description: "Log driver options"
+        description: 'Log driver options'
       - type: String
         name: lxc-conf
         title: 'lxc-conf'
-        description: "Add custom lxc options"
+        description: 'Add custom lxc options'
       - type: String
         name: memory
         title: 'memory'
-        description: "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)"
+        description: 'Memory limit (format: <number><optional unit>, where unit = b, k, m or g)'
       - type: String
         name: memory-swap
         title: 'memory-swap'
-        description: "Total memory limit (memory + swap, format: <number><optional unit>, where unit = b, k, m or g)"
+        description: 'Total memory limit (memory + swap, format: <number><optional unit>, where unit = b, k, m or g)'
       - type: String
         name: name
         title: 'name'
-        description: "the identifying name"
+        description: 'The identifying name'
       - type: FreeSelect
         name: net
         title: 'net'
-        description: "Set the Network mode for the container"
+        description: 'Set the Network mode for the container'
         values: bridge,none,host,container:<name|id>
       - type: Select
         name: oom-kill-disable
         title: 'oom-kill-disable'
-        description: "Whether to disable OOM Killer for the container or not."
+        description: 'Whether to disable OOM Killer for the container or not.'
         values: true,false
       - type: Select
         name: privileged
         title: 'privileged'
-        description: "Give extended privileges to this container"
+        description: 'Give extended privileges to this container'
         values: true,false
       - type: String
         name: publish
         title: 'publish'
-        description: "Publish a container port (eg xxxx:yyyy)"
+        description: 'Publish a container port (eg xxxx:yyyy)'
       - type: FreeSelect
         name: restart
         title: 'restart'
-        description: "Restart policy to apply when a container exits"
+        description: 'Restart policy to apply when a container exits'
         values: no,always,on-failure[:max-retries]
       - type: Select
         name: rm
         title: 'rm'
-        description: "Automatically remove the container when it exits"
+        description: 'Automatically remove the container when it exits'
         values: true,false
       - type: String
         name: security-opt
         title: 'security-opt'
-        description: "Security Options"
+        description: 'Security Options'
       - type: String
         name: read-only
         title: 'read-only'
-        description: "Mount the container's root filesystem as read only"
+        description: 'Mount the containers root filesystem as read only'
       - type: String
         name: volume
         title: 'volume'
-        description: "Bind mount a volume"
+        description: 'Bind mount a volume'
       - type: String
         name: volumes-from
         title: 'volumes-from'
-        description: "Mount volumes from the specified container(s)"
+        description: 'Mount volumes from the specified container(s)'
       - type: String
         name: ulimit
         title: 'ulimit'
-        description: "Ulimit options"
+        description: 'Ulimit options'
       - type: String
         name: uts
         title: 'uts'
-        description: "UTS namespace to use"
+        description: 'UTS namespace to use'
       - type: String
         name: label
         title: 'label'
-        description: "Set meta data on a container"
+        description: 'Set meta data on a container'
       - type: Select
         name: interactive
         title: 'interactive'
-        description: "Keep STDIN open even if not attached"
+        description: 'Keep STDIN open even if not attached'
         values: true,false
       - type: String
         name: workdir
         title: 'working-directory'
-        description: "Working directory inside the container"  
+        description: 'Working directory inside the container'
+      - type: String
+        name: user
+        title: 'user'
+        description: 'Username or UID (format: <name|uid>[:<group|gid>])'
       - type: Select
         name: tty
         title: 'tty'
-        description: "Allocate a pseudo-TTY"
+        description: 'Allocate a pseudo-TTY'
         values: true,false
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: 'Write debug messages to stderr'
       - type: String
         name: docker-cert-path
         title: 'docker-cert-path'
-        description: "the certificate path"
+        description: 'The certificate path'
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'
       - type: String
         name: docker-host
         title: 'docker-host'
-        description: "the docker host"
+        description: 'The docker host'
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'
       - type: Select
         name: docker-tls-verify
         title: 'docker-tls-verify'
-        description: "verify TLS"
+        description: 'verify TLS'
         values: 1,0
         renderingOptions:
           grouping: secondary


### PR DESCRIPTION
- Add debug option to all steps
- By default now only standard out is printed for cleaner/more readable rundeck log output
- Allow specifying which user to use inside the docker container
- Fix DOCKER_TLS_VERIFY not being set when specified and DOCKER_CERT_PATH is not specified
- PEP8 style compliance
- Pythonic code style
- Consistent quoting

**Hold for some testing**