### PR TITLE
Fixes and improvements

### DIFF
--- a/docker-container/contents/container-inspect
+++ b/docker-container/contents/container-inspect
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -50,7 +50,7 @@ p = Popen(
     shlex.split('docker inspect %s' % (args.container)),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 exitcode = p.wait()
 

--- a/docker-container/contents/container-kill
+++ b/docker-container/contents/container-kill
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -51,7 +51,7 @@ p = Popen(
     shlex.split('docker kill %s' % (args.container)),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 exitcode = p.wait()
 

--- a/docker-container/contents/container-pause
+++ b/docker-container/contents/container-pause
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -50,7 +50,7 @@ p = Popen(
     shlex.split('docker pause %s' % (args.container)),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 exitcode = p.wait()
 

--- a/docker-container/contents/container-stats
+++ b/docker-container/contents/container-stats
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -50,7 +50,7 @@ p = Popen(
     shlex.split('docker stats --no-stream --format "%s" %s' % (args.format, args.container)),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 exitcode = p.wait()
 

--- a/docker-container/contents/container-unpause
+++ b/docker-container/contents/container-unpause
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -50,7 +50,7 @@ p = Popen(
     shlex.split('docker unpause %s' % (args.container)),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 exitcode = p.wait()
 

--- a/docker-container/contents/node-execute
+++ b/docker-container/contents/node-execute
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -57,7 +57,7 @@ p = Popen(
     shlex.split('docker exec %s %s' % (args.container, args.command)),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 
 # Print lines to stdout while waiting for command to finish

--- a/docker-container/contents/run-image
+++ b/docker-container/contents/run-image
@@ -4,7 +4,7 @@ import logging
 import shlex
 import sys
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 
 if os.environ.get('RD_CONFIG_DEBUG') == 'true':
     log_level = 'DEBUG'
@@ -90,7 +90,7 @@ p = Popen(
     shlex.split(command_string),
     shell=False,
     stdout=PIPE,
-    stderr=PIPE
+    stderr=STDOUT
 )
 
 # Print lines to stdout while waiting for command to finish

--- a/docker-container/plugin.yaml
+++ b/docker-container/plugin.yaml
@@ -1,5 +1,5 @@
 name: docker-container-node-executor
-version: 1.3.1
+version: 1.3.2
 rundeckPluginVersion: 1.2
 author: alexh
 date: Thu Aug 6 19:32:08 PDT 2015
@@ -51,8 +51,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        default: '1'
-        values: 1,0
+        values: 1
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'
@@ -77,7 +76,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        values: 1,0
+        values: 1
       - type: String
         name: container
         title: 'container'
@@ -108,7 +107,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        values: 1,0
+        values: 1
       - type: String
         name: attributes
         title: 'Default attributes'
@@ -415,7 +414,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'verify TLS'
-        values: 1,0
+        values: 1
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'

--- a/docker-container/plugin.yaml
+++ b/docker-container/plugin.yaml
@@ -51,7 +51,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        values: 1
+        values: true,
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'
@@ -76,7 +76,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        values: 1
+        values: true,
       - type: String
         name: container
         title: 'container'
@@ -107,7 +107,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        values: 1
+        values: true,
       - type: String
         name: attributes
         title: 'Default attributes'
@@ -414,7 +414,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'verify TLS'
-        values: 1
+        values: true,
         renderingOptions:
           grouping: secondary
           groupName: 'API Connection'


### PR DESCRIPTION
## Fixes
1. remove default tls-verify value for node-execute (Resolves https://github.com/rundeck-plugins/docker/issues/21)
2. any value for tls-verify will cause it to turn on so remove 0 as an option (Resolves https://github.com/rundeck-plugins/docker/issues/21)

## Improvements
1. redirect stderr to stdout so we can see docker error output (Resolves https://github.com/rundeck-plugins/docker/issues/23)
