### PR TITLE
Multiple changes and fixes

### DIFF
--- a/docker-container/contents/node-execute
+++ b/docker-container/contents/node-execute
@@ -22,9 +22,21 @@ parser = argparse.ArgumentParser(
     description='Execute a command string in the container.'
 )
 parser.add_argument('container', help='the container ID')
-parser.add_argument('user', help='the user ID')
 parser.add_argument('command', help='the command string to execute')
 args = parser.parse_args()
+
+possible_opts = ['detach', 'env', 'interactive', 'privileged', 'tty', 'user']
+OPTIONS = []
+
+for opt in possible_opts:
+    env_var_name = "RD_CONFIG_%s" % opt.upper().replace('-', '_')
+    if env_var_name in os.environ:
+        for env_var_value in shlex.split(os.environ[env_var_name]):
+            OPTIONS.append("--%s='%s'" % (opt, env_var_value))
+            log.debug("appended option: --%s='%s'" % (opt, env_var_value))
+
+if 'RD_CONFIG_DOCKER_HOST' in os.environ:
+    os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
 
 if 'RD_CONFIG_DOCKER_HOST' in os.environ:
     os.environ['DOCKER_HOST'] = os.environ['RD_CONFIG_DOCKER_HOST']
@@ -48,13 +60,12 @@ else:
         'RD_CONFIG_DOCKER_TLS_VERIFY environment variable not defined.'
     )
 
-log.debug(
-    "Executing command string '%s' in container '%s'"
-    "..." % (args.command, args.container)
-)
+command_string = "docker exec %s %s sh -c '%s'" % (' '.join(OPTIONS), args.container, args.command)
+
+log.debug("Executing: '%s' ..." % command_string)
 
 p = Popen(
-    shlex.split('docker exec %s %s' % (args.container, args.command)),
+    shlex.split(command_string),
     shell=False,
     stdout=PIPE,
     stderr=STDOUT

--- a/docker-container/contents/run-image
+++ b/docker-container/contents/run-image
@@ -31,7 +31,7 @@ possible_opts = ['add-host', 'blkio-weight', 'cap-add', 'cap-drop', 'cidfile',
                  'ipc', 'label', 'log-driver', 'log-opt', 'lxc-conf', 'memory',
                  'memory-swap', 'name', 'net', 'oom-kill-disable', 'publish',
                  'privileged', 'restart', 'rm', 'security-opt', 'volume',
-                 'volume-from', 'ulimit', 'uts', 'tty', 'workdir', 'user']
+                 'volume-from', 'ulimit', 'uts', 'tty', 'workdir', 'user', 'mount']
 OPTIONS = []
 
 for env_var_name, env_var_value in os.environ.iteritems():
@@ -76,14 +76,11 @@ else:
 if args.command in {'${option.command}', '${config.command}'}:
     args.command = None
 
-COMMAND = ['docker', 'run']
-COMMAND.extend(OPTIONS)
-COMMAND.append(args.image)
+if args.command:
+    command_string = "docker run %s %s sh -c '%s'" % (' '.join(OPTIONS), args.image, args.command)
+else:
+    command_string = "docker run %s %s" % (' '.join(OPTIONS), args.image)
 
-if args.command is not None:
-    COMMAND.append(args.command)
-
-command_string = " ".join(COMMAND)
 log.debug("Executing: '%s' ..." % command_string)
 
 p = Popen(

--- a/docker-container/plugin.yaml
+++ b/docker-container/plugin.yaml
@@ -11,7 +11,7 @@ providers:
     plugin-type: script
     script-interpreter: python -u
     script-file: node-execute
-    script-args: ${config.container} ${config.user} ${config.command}
+    script-args: ${config.container} ${config.command}
     config:
       - type: String
         name: container

--- a/docker-container/plugin.yaml
+++ b/docker-container/plugin.yaml
@@ -290,7 +290,7 @@ providers:
       - type: Select
         name: detach
         title: 'detach'
-        description: 'Detached mode: run command in the background'
+        description: 'Run container in background and print container ID'
         values: true,false
       - type: String
         name: device

--- a/docker-container/plugin.yaml
+++ b/docker-container/plugin.yaml
@@ -1,5 +1,5 @@
 name: docker-container-node-executor
-version: 1.3.2
+version: 1.3.3
 rundeckPluginVersion: 1.2
 author: alexh
 date: Thu Aug 6 19:32:08 PDT 2015
@@ -23,12 +23,34 @@ providers:
         title: 'command'
         description: 'The command string to execute in the container'
         required: true
+      - type: Select
+        name: detach
+        title: 'detach'
+        description: 'Detached mode: run command in the background'
+        values: true,false
+      - type: String
+        name: env
+        title: 'environment variables'
+        description: 'Set of environment variables'
+      - type: Select
+        name: interactive
+        title: 'interactive'
+        description: 'Keep STDIN open even if not attached'
+        values: true,false
+      - type: Select
+        name: privileged
+        title: 'privileged'
+        description: 'Give extended privileges to the command'
+        values: true,false
+      - type: Select
+        name: tty
+        title: 'tty'
+        description: 'Allocate a pseudo-TTY'
+        values: true,false
       - type: String
         name: user
-        title: 'User'
-        description: 'User to execute command as.'
-        default: root
-        required: true
+        title: 'user'
+        description: 'Username or UID (format: <name|uid>[:<group|gid>])'
       - type: Boolean
         name: debug
         title: Debug?
@@ -80,7 +102,7 @@ providers:
       - type: String
         name: container
         title: 'container'
-        description: 'The container to dispatch.'
+        description: 'The container to dispatch'
       - type: Boolean
         name: debug
         title: Debug?
@@ -228,7 +250,7 @@ providers:
       - type: Integer
         name: blkio-weight
         title: 'blkio-weight'
-        description: 'Block IO weight (relative weight) accepts a weight value between 10 and 1000.'
+        description: 'Block IO weight (relative weight) accepts a weight value between 10 and 1000'
       - type: String
         name: cap-add
         title: 'cap-add'
@@ -268,7 +290,7 @@ providers:
       - type: Select
         name: detach
         title: 'detach'
-        description: 'Run container in background and print container ID'
+        description: 'Detached mode: run command in the background'
         values: true,false
       - type: String
         name: device
@@ -281,7 +303,7 @@ providers:
       - type: String
         name: env
         title: 'environment variables'
-        description: 'Set of environment variables.'
+        description: 'Set of environment variables'
       - type: String
         name: image
         title: 'image'
@@ -314,6 +336,10 @@ providers:
         title: 'memory-swap'
         description: 'Total memory limit (memory + swap, format: <number><optional unit>, where unit = b, k, m or g)'
       - type: String
+        name: mount
+        title: 'mount'
+        description: 'Attach a filesystem mount to the container'
+      - type: String
         name: name
         title: 'name'
         description: 'The identifying name'
@@ -325,7 +351,7 @@ providers:
       - type: Select
         name: oom-kill-disable
         title: 'oom-kill-disable'
-        description: 'Whether to disable OOM Killer for the container or not.'
+        description: 'Whether to disable OOM Killer for the container or not'
         values: true,false
       - type: Select
         name: privileged


### PR DESCRIPTION
### Changes
- add more input options to node-execute (detach, env, interactive, privileged, tty, user)
- add mount option for run-image https://github.com/rundeck-plugins/docker/issues/25 
- remove periods at end of descriptions for uniformity with other descriptions
- bump plugin version

### Fixes
- make user optional for node-execute https://github.com/rundeck-plugins/docker/issues/27 https://github.com/rundeck-plugins/docker/issues/28 
- by default all commands to be executed in a container will be wrapped with sh -c https://github.com/rundeck-plugins/docker/issues/29
