### PR TITLE
Fix file copier docker-tls-verify option values

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -117,7 +117,7 @@ providers:
         name: docker-tls-verify
         title: 'docker-tls-verify'
         description: 'Verify TLS'
-        values: true
+        values: true,
       - type: Boolean
         name: debug
         title: Debug?


### PR DESCRIPTION
Fix missing comma in file-copier declaration that prevent  docker-tls-verify to be set in "default file copier" Rundeck UI dialog.