### PR TITLE
Resource Model: Add option to retrieve all containers instead of running only

### DIFF
--- a/contents/model-source
+++ b/contents/model-source
@@ -233,6 +233,9 @@ log.debug('filter: %s' % filter)
 
 ps_command=["docker","ps","--format",'"{{.ID}}"']
 
+if 'RD_CONFIG_ALL_CONTAINERS' in os.environ:
+    ps_command.append("--all")
+
 if filter:
     for value in filter.split(","):
         ps_command.append("--filter")

--- a/contents/model-source
+++ b/contents/model-source
@@ -233,7 +233,7 @@ log.debug('filter: %s' % filter)
 
 ps_command=["docker","ps","--format",'"{{.ID}}"']
 
-if 'RD_CONFIG_ALL_CONTAINERS' in os.environ:
+if os.environ.get('RD_CONFIG_ALL_CONTAINERS') == 'true':
     ps_command.append("--all")
 
 if filter:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -126,7 +126,7 @@ providers:
     service: ResourceModelSource
     resource-format: resourcejson
     title: docker / container / model
-    description: 'read docker containers as Nodes'
+    description: 'Read docker containers as nodes'
     plugin-type: script
     script-interpreter: python -u
     script-file: model-source
@@ -163,6 +163,10 @@ providers:
         name: filter
         title: Filter
         description: 'Filter the list of containers (docker ps --filter syntax), eg: name=rundeck*,status=running. Further information here: https://docs.docker.com/engine/reference/commandline/ps/'
+      - type: Boolean
+        name: all-containers
+        title: 'All containers'
+        description: 'Include all containers. If unchecked only running containers will be loaded.'
       - type: Boolean
         name: debug
         title: Debug?


### PR DESCRIPTION
This PR adds a new option to the resource model source plugin to be able to retrieve all existing containers instead of running containers only (which is the default behavior of "docker ps" command)

This option will add "--all" to docker ps command arguments so containers in different states will be also retrieved by the plugin.