### PR TITLE
Add RD_GLOBALS_

### DIFF
--- a/contents/run-image
+++ b/contents/run-image
@@ -37,6 +37,7 @@ OPTIONS = []
 for env_var_name, env_var_value in os.environ.iteritems():
     if (env_var_name.startswith('RD_OPTION') or
        env_var_name.startswith('RD_NODE') or
+       env_var_name.startswith('RD_GLOBALS') or
        env_var_name.startswith('RD_JOB')) and \
        env_var_value:
         OPTIONS.append("--env=%s='%s'" % (env_var_name, env_var_value))


### PR DESCRIPTION
We are missing the "globals".
This fix adds them to the container.
https://docs.rundeck.com/docs/administration/configuration/config-file-reference.html#global-execution-variables