### PR TITLE
Add RD_FILE_

### DIFF
--- a/contents/run-image
+++ b/contents/run-image
@@ -39,6 +39,7 @@ for env_var_name, env_var_value in os.environ.items():
     if (env_var_name.startswith('RD_OPTION') or
        env_var_name.startswith('RD_NODE') or
        env_var_name.startswith('RD_GLOBALS') or
+       env_var_name.startswith('RD_FILE') or
        env_var_name.startswith('RD_JOB')) and \
        env_var_value:
         OPTIONS.append("--env=%s='%s'" % (env_var_name, env_var_value))


### PR DESCRIPTION
Add RD_FILE_ vars so we are able to mount "/home/rundeck/var/upload/" (or based on the installation "/var/lib/rundeck/upload/") into the container and do stuff with uploaded files trough the [Rundeck File Option](https://docs.rundeck.com/docs/manual/job-options.html#file-option-type). The RD_FILE_ var contains the exact path where the file is uploaded. The RD_FILE_*_FILENAME var contains the original filename. 