### PR TITLE
Add Python3 (color) output support

### DIFF
--- a/contents/run-image
+++ b/contents/run-image
@@ -100,7 +100,7 @@ p = Popen(
 while True:
     line = p.stdout.readline().rstrip()
     if line:
-        print ( line )
+        print ( line.decode() )
     if p.poll() is not None:
         break
 


### PR DESCRIPTION
This change adds Python3 support to the plugin. Output is now shown correctly when you use Python 3.